### PR TITLE
Fixed the PDF Download Bug

### DIFF
--- a/src/components/resume/ResumeGenerator.tsx
+++ b/src/components/resume/ResumeGenerator.tsx
@@ -45,7 +45,29 @@ const ResumeGenerator = ({ data, templateName }: ResumeGeneratorProps) => {
 
     setIsGenerating(true);
     try {
-      const pdfBlob = await generatePDFFromElement(resumePreviewRef.current);
+      const hiddenElement = resumePreviewRef.current;
+      const originalParent = hiddenElement.parentElement;
+      const originalStyle = hiddenElement.getAttribute('style');
+      
+      hiddenElement.style.position = 'fixed';
+      hiddenElement.style.top = '0';
+      hiddenElement.style.left = '0';
+      hiddenElement.style.width = '800px';
+      hiddenElement.style.height = 'auto';
+      hiddenElement.style.opacity = '1';
+      hiddenElement.style.pointerEvents = 'auto';
+      hiddenElement.style.zIndex = '9999';
+      
+      await new Promise(resolve => setTimeout(resolve, 500));
+      
+      const pdfBlob = await generatePDFFromElement(hiddenElement);
+      
+      if (originalStyle) {
+        hiddenElement.setAttribute('style', originalStyle);
+      } else {
+        hiddenElement.removeAttribute('style');
+      }
+      
       downloadFile(pdfBlob, `${data.personalInfo.fullName || 'resume'}.pdf`);
       toast({
         title: "PDF Generated",
@@ -68,8 +90,9 @@ const ResumeGenerator = ({ data, templateName }: ResumeGeneratorProps) => {
     setIsGenerating(true);
     try {
       const canvas = await html2canvas(resumePreviewRef.current, {
-        scale: 2,
         useCORS: true,
+        allowTaint: true,
+        background: '#ffffff'
       });
 
       canvas.toBlob((blob) => {
@@ -109,8 +132,8 @@ const ResumeGenerator = ({ data, templateName }: ResumeGeneratorProps) => {
         <h3 className="text-xl font-bold mb-4">Generate & Download Resume</h3>
 
         {/* Hidden Resume Preview for PDF/Image Generation */}
-        <div ref={resumePreviewRef} className="hidden">
-          <div className="w-[800px]">
+        <div ref={resumePreviewRef} className="fixed -top-[9999px] -left-[9999px] opacity-0 pointer-events-none">
+          <div className="w-[800px] bg-white">
             <ResumePreview data={data} templateName={templateName} />
           </div>
         </div>

--- a/src/services/documentService.ts
+++ b/src/services/documentService.ts
@@ -144,29 +144,38 @@ export const generateWordDocument = async (resumeData: ResumeData): Promise<Blob
 };
 
 export const generatePDFFromElement = async (element: HTMLElement): Promise<Blob> => {
+
+  await new Promise(resolve => setTimeout(resolve, 200));
+  
+  const rect = element.getBoundingClientRect();
+  const width = rect.width || element.scrollWidth || 800;
+  const height = rect.height || element.scrollHeight || 1000;
+  
   const canvas = await html2canvas(element, {
-    scale: 2,
     useCORS: true,
+    allowTaint: true,
+    background: '#ffffff',
+    width: width,
+    height: height
   });
 
   const imgData = canvas.toDataURL('image/png');
   const pdf = new jsPDF('p', 'mm', 'a4');
   
-  const imgWidth = 210;
-  const pageHeight = 295;
-  const imgHeight = (canvas.height * imgWidth) / canvas.width;
-  let heightLeft = imgHeight;
-  let position = 0;
-
-  pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
-  heightLeft -= pageHeight;
-
-  while (heightLeft >= 0) {
-    position = heightLeft - imgHeight;
-    pdf.addPage();
-    pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
-    heightLeft -= pageHeight;
-  }
+  // A4 size
+  const pdfWidth = 210;
+  const pdfHeight = 297;
+  const imgWidth = canvas.width;
+  const imgHeight = canvas.height;
+  
+  const ratio = Math.min(pdfWidth / (imgWidth * 0.264583), pdfHeight / (imgHeight * 0.264583));
+  const pdfImgWidth = imgWidth * 0.264583 * ratio;
+  const pdfImgHeight = imgHeight * 0.264583 * ratio;
+  
+  const x = (pdfWidth - pdfImgWidth) / 2;
+  const y = 10;
+  
+  pdf.addImage(imgData, 'PNG', x, y, pdfImgWidth, pdfImgHeight);
 
   return pdf.output('blob');
 };


### PR DESCRIPTION
Now the pdf download button perfectly generates a pdf file and gets it ready to be downloaded locally.

I hides the element first. then upon button click activates the canvas and uses the hook `generatePDFFromElement` from `@/services/documentService` to generate the pdf correctly and then downloads it using `downloadFile` using same 
library.

Fixes #11 
<br>
<img width="1919" height="863" alt="image" src="https://github.com/user-attachments/assets/b251a334-dd1f-4b31-a815-a8fa456f716d" />

<img width="390" height="131" alt="image" src="https://github.com/user-attachments/assets/a3e06b6f-0477-473a-8d5a-326d6b054f69" />

