### PR TITLE
[FEATURE] Added full preview

### DIFF
--- a/src/components/resume/FullPreviewModal.tsx
+++ b/src/components/resume/FullPreviewModal.tsx
@@ -1,0 +1,67 @@
+import { ResumeData } from "@/pages/Builder";
+import ResumePreview from "./ResumePreview";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { X, Download, Printer } from "lucide-react";
+
+interface FullPreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  data: ResumeData;
+  templateName?: 'default' | 'modern' | 'professional' | 'creative' | 'minimalist' | 'bold';
+}
+
+const FullPreviewModal = ({ isOpen, onClose, data, templateName = 'default' }: FullPreviewModalProps) => {
+  const handlePrint = () => {
+    window.print();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-7xl w-[95vw] h-[90vh] max-h-[90vh] p-0 overflow-hidden">
+        <DialogHeader className="p-6 pb-0 border-b">
+          <div className="flex items-center justify-between">
+            <DialogTitle className="text-xl font-semibold">
+              Resume Preview - {templateName.charAt(0).toUpperCase() + templateName.slice(1)} Template
+            </DialogTitle>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handlePrint}
+                className="flex items-center gap-2"
+              >
+                <Printer className="w-4 h-4" />
+                Print
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onClose}
+                className="flex items-center gap-2"
+              >
+                <X className="w-4 h-4" />
+                Close
+              </Button>
+            </div>
+          </div>
+        </DialogHeader>
+        
+        <div className="flex-1 overflow-auto p-6 bg-gray-50">
+          <div className="flex justify-center">
+            <div className="bg-white shadow-2xl" style={{ width: '210mm', minHeight: '297mm' }}>
+              <ResumePreview data={data} templateName={templateName} />
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default FullPreviewModal;

--- a/src/pages/Builder.tsx
+++ b/src/pages/Builder.tsx
@@ -12,6 +12,7 @@ import SkillsForm from "@/components/resume/SkillsForm";
 import ResumePreview from "@/components/resume/ResumePreview";
 import ResumeAnalysisComponent from "@/components/resume/ResumeAnalysis";
 import ResumeGenerator from "@/components/resume/ResumeGenerator";
+import FullPreviewModal from "@/components/resume/FullPreviewModal";
 import FloatingChatBot from "@/components/FloatingChatBot";
 import CodingProfilesForm from "@/components/resume/CodingProfilesForm";
 import HobbiesForm from "@/components/resume/HobbiesForm";
@@ -119,6 +120,7 @@ const Builder = () => {
 
   const [templateName, setTemplateName] = useState<'default' | 'modern' | 'professional' | 'creative' | 'minimalist' | 'bold'>('default');
   const [showGenerateModal, setShowGenerateModal] = useState(false);
+  const [showFullPreview, setShowFullPreview] = useState(false);
   
   // Mobile state for preview visibility
   const [showMobilePreview, setShowMobilePreview] = useState(false);
@@ -589,6 +591,17 @@ const Builder = () => {
                     </Button>
                   </div>
                 </div>
+                <div className="mt-3">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowFullPreview(true)}
+                    className="w-full flex items-center justify-center gap-2 bg-blue-50 hover:bg-blue-100 border-blue-200 text-blue-700 hover:text-blue-800"
+                  >
+                    <FileText className="w-4 h-4" />
+                    View Full Preview
+                  </Button>
+                </div>
               </div>
               <div className="flex-1 overflow-auto bg-gray-200 p-4 min-h-[600px] flex justify-center">
                 <div className={`w-full ${templateName === 'creative' ? 'max-w-full' : 'max-w-[800px]'} bg-white shadow-xl transition-all duration-300 ease-in-out`}>
@@ -603,6 +616,15 @@ const Builder = () => {
       {/* Floating Chat Bot */}
       <FloatingChatBot />
 
+      {/* Full Preview Modal */}
+      <FullPreviewModal
+        isOpen={showFullPreview}
+        onClose={() => setShowFullPreview(false)}
+        data={resumeData}
+        templateName={templateName}
+      />
+
+      {/* Generate Modal */}
       <Dialog open={showGenerateModal} onOpenChange={setShowGenerateModal}>
         <DialogContent className="max-w-2xl">
           <DialogHeader>


### PR DESCRIPTION
# Fixes #60 
Implemented a full resume preview mode.

## Checklist:
- [x] Button appears in Resume Preview section
- [x] Clicking button opens full-size resume view
- [x] Full-size view displays complete resume content
- [x] Button is accessible and styled appropriately
- [x] Preview can be closed/returned to main view


## Screenshots:
<img width="1919" height="855" alt="image" src="https://github.com/user-attachments/assets/7a4873f4-9e12-4952-a921-956dd9395459" />
<img width="910" height="728" alt="image" src="https://github.com/user-attachments/assets/80c239be-b913-4e12-9a6e-ec3da70483bb" />
